### PR TITLE
Arc polynomials support BigFloat

### DIFF
--- a/src/arc.jl
+++ b/src/arc.jl
@@ -96,9 +96,9 @@ function ldiv(Pn::SubQuasiArray{T,2,<:UltrasphericalArc,<:Tuple{Inclusion,OneTo}
     @assert P.h == 0
     N = maximum(jr)
     ret = Array{T}(undef, N)
-    ret[1:2:end] = P.T[:,Base.OneTo((N+1) ÷ 2)] \ BroadcastQuasiVector{Float64}(y -> f[CircleCoordinate(asin(1-y))] + f[CircleCoordinate(π-asin(1-y))], axes(P.T,1))
+    ret[1:2:end] = P.T[:,Base.OneTo((N+1) ÷ 2)] \ BroadcastQuasiVector{T}(y -> f[CircleCoordinate(asin(1-y))] + f[CircleCoordinate(π-asin(1-y))], axes(P.T,1))
     if N > 1
-        ret[2:2:end] = P.U[:,Base.OneTo(N÷2)] \ BroadcastQuasiVector{Float64}(function(y)
+        ret[2:2:end] = P.U[:,Base.OneTo(N÷2)] \ BroadcastQuasiVector{T}(function(y)
             xy = CircleCoordinate(asin(1-y))
             xỹ = CircleCoordinate(π-asin(1-y))
             (f[xy] - f[xỹ])/xy[1]


### PR DESCRIPTION
```julia
using GenericLinearAlgebra

A = UltrasphericalArc(BigFloat(0))
x = first.(axes(A, 1))

A \ x.^2
```

Before:
```
10-element Vector{BigFloat}:
  0.6266570686577501237418697294710815387301076006219827056114522097549345545095881
  1.579384904325175289713685821181340156169059527602379113372968755218794638903481e-78
  0.4320945820043760181850978971939310258251424715431059324202227311975443322859464
  2.667514928953125173970603404904795939647722489024290142999096452699048745620641e-79
 -0.09820291773580684573977088744825259092928801837738922598107293674248707940241149
 -1.442048352461885040604872418742738493906933090795807162561948995118049228162715e-78
 -1.990224035079816979561897717267298561926743952964649748598214290810425639616236e-17
 -2.969140122380793268212046445016540036849598353109808678513785017100104837465563e-78
 -2.514867221742895594217659052686975001144800622746047938601572687289497258440182e-17
  5.597608223645937297889954726324128240054519837453084837283692553055750595882384e-78
```

After:
```
10-element Vector{BigFloat}:
  0.6266570686577501256039413212027613132517466851524845791574808940855734136518756
  1.579384904325175106216034064005789976586799450847508802988908217143274391081595e-78
  0.4320945820043760182689916594491047512161994910339778624645352561809880766542957
  2.667514928953125467101937014473873884654441181514628458588951737565738839578713e-79
 -0.09820291773580684111937186742994249157980540653259681661553987046500991023191974
 -1.442048352461884794196338642164145526353657456612554904444951064207236072465664e-78
 -9.74144892810549975098966822161038387604775158983389387593086991102400892494358e-77
 -2.969140122380793419418736138529001699089781990080416595931362565111177650532711e-78
 -2.042998316866570086665888752032177729560014569534608298979946328561979649536787e-76
  5.59760822364593723304595255620009579272102227729331233068321825790772565399336e-78
```